### PR TITLE
Lewijw javac.compile refactor

### DIFF
--- a/safs/safs.build.xml
+++ b/safs/safs.build.xml
@@ -200,6 +200,7 @@
       	  'org/safs/jmx/**',
       	  'org/safs/jrex/**',
       	  'org/safs/selenium/install/**',
+      	  'org/safs/test/compile/groovy/**',
       	  'org/safs/tools/drivers/test/**',
       	  'org/safs/tools/engines/test/**',
       	  'org/safs/tools/expressions/test/**',

--- a/safs/safs.build.xml
+++ b/safs/safs.build.xml
@@ -170,10 +170,11 @@
   <target name="javac.compile">
     <taskdef name="groovy" classname="org.codehaus.groovy.ant.Groovy" classpath="${safs.classpath}" />
     <groovy>
-      ant.javac(
+      ant.typedef(name:'groovyc', classname:'org.codehaus.groovy.ant.Groovyc', classpath:'${safs.classpath}')
+      ant.groovyc(
+        srcdir:'${safssource}',
         destdir:'${classes}',
         classpath:'${safs.classpath}',
-        debug:'on',
         encoding:'UTF-8',
         excludes:'''
           **/*.sh **/*.bat **/*.vbs **/*.wsf 
@@ -183,8 +184,8 @@
           **/*.classpath **/*.project
         ''',
       ) {
-      	src(path:'${safssource}')
-      	[
+        javac(debug:'on')
+        [
       	  'eclipse/**',
       	  'com/jayway/android/robotium/solo/**',
       	  'eclipse/**',
@@ -202,19 +203,19 @@
       	  'org/safs/tools/drivers/test/**',
       	  'org/safs/tools/engines/test/**',
       	  'org/safs/tools/expressions/test/**',
-      	].each { path ->
-          exclude(name:path)
-      	}
-      	if (!properties.'Private.FTPServer.isConnected') {
-      	  // Exclude all things importing rational
-      	  [
-      	    'TestScript.java',
-      	    'org/safs/rational/**/*.java',
-      	    'resources/*.java',
-      	  ]. each { path ->
-      	    exclude(name:path)
-      	  }
-      	}
+        ].each { path ->
+            exclude(name:path)
+        }
+        if (!properties.'Private.FTPServer.isConnected') {
+          // Exclude all things importing rational
+          [
+            'TestScript.java',
+            'org/safs/rational/**/*.java',
+            'resources/*.java',
+          ]. each { path ->
+            exclude(name:path)
+          }
+        }
       }
     </groovy>
   </target>


### PR DESCRIPTION
I am waiting for Jenkins to perform a SAFS build to test the previous pull request (of this branch) that I just merged into master.   In the meantime, I am creating this pull request so you can review this change.  The groovyc task is used to do the compile so any Groovy classes will be compiled.  The groovyc task uses javac, and I made sure the generated classes (under the classes directory) were the same before and after the use of groovyc.  At the moment, there are 2 Groovy classes in SAFS, and I put in an exclude so they will not be compiled.  As such, the generated classes are the same number and content as before this change.  There is no change in functionality (yet).  When this change is merged into master, then the john_oauth2_curl_and_debug_logging branch of SAFS Core will have its Groovy classes compiled.