### PR TITLE
Change selenium.build.xml so the tests in SeleniumPlus-Plugin are cal…

### DIFF
--- a/safs/selenium.build.xml
+++ b/safs/selenium.build.xml
@@ -208,6 +208,18 @@
         <fileset dir="${safssource}/eclipse/plugins/Seleniumplus_plugin/" includes="preferences.properties"/>
       </copy>
       
+      <!--
+      Run the SeleniumPlus-Plugin test.
+      -->
+      <ant
+        target="test.compile.and.run.only"
+        dir="${basedir}/source/common/eclipse/plugins/Seleniumplus_plugin"
+        useNativeBasedir="true"
+        >
+        <property name="ECLIPSEJARS" location="${ECLIPSEJARS}" />
+        <property name="SAFSJARS" location="${basedir}/safsjars" />
+      </ant>
+
       <zip destfile="${seleniumdist}/TestDesigner.ZIP"
            basedir="${seleniumdist}"
            includes="Setup.bat


### PR DESCRIPTION
…led.

Let me know if you see a problem with this change.  The hope is to have tests in the SeleniumPlus-Plugin project that can be run conveniently in Eclipse while developing.  This change will work towards getting those same tests running in the SeleniumPlus build.