### PR TITLE
When calling the SeleniumPlus-Plugin test.compile.and.run.only target…

### DIFF
--- a/safs/selenium.build.xml
+++ b/safs/selenium.build.xml
@@ -218,6 +218,7 @@
         >
         <property name="ECLIPSEJARS" location="${ECLIPSEJARS}" />
         <property name="SAFSJARS" location="${basedir}/safsjars" />
+        <property name="seleniumdist" location="${seleniumdist}" />
       </ant>
 
       <zip destfile="${seleniumdist}/TestDesigner.ZIP"


### PR DESCRIPTION
…, pass in the full path of seleniumdist.